### PR TITLE
Conversione delle soluzioni in PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # doExercises
-Script python per il download degli esercizi della piattaforma DoExercises (corso di probabilità e statistica)
+Script python per il download degli esercizi della piattaforma DoExercises (corso di probabilità e statistica).
 
 ### Utilizzo
-Usare `python doexercises.py --help` ottenere informazioni sui comandi possibili 
+Usare `python doexercises.py --help` ottenere informazioni sui comandi possibili.
+
+### PDF
+Per convertire le soluzioni in PDF occorre [`wkhtmltopdf`](https://github.com/wkhtmltopdf/wkhtmltopdf/releases). Se non lo si vuole installare, basta scaricarlo in una qualunque cartella e indicare il percorso all'eseguibile con il comando `--wk <percorso>` allo script.
+
+Su Linux/X11 è possibile installare [`xfvb-run`](https://manpages.ubuntu.com/manpages/trusty/man1/xvfb-run.1.html) (fa parte del pacchetto `xfvb`, disponibile tramite i vari package manager). Lo script controlla se è installato e, se lo trova, converte i file in PDF usando vari processi in parallelo (controllati da `--jobs`), velocizzando **molto** la conversione.

--- a/doexercises.py
+++ b/doexercises.py
@@ -1,4 +1,5 @@
 import argparse
+import glob
 import json
 import os
 import re
@@ -8,13 +9,16 @@ import urllib
 from multiprocessing.pool import ThreadPool
 from shutil import copy2
 from threading import Thread
-from typing import Dict, List
+from typing import List
 
 import requests
+import subprocess
 
-root_url = 'http://datascience.maths.unitn.it'
-solutions_address = '/ocpu/library/doexercises/R/getSolutions'
-renderRmd_address = '/ocpu/library/doexercises/R/renderRmd'
+URLS = {
+    "root": "http://datascience.maths.unitn.it",
+    "solutions": "/ocpu/library/doexercises/R/getSolutions",
+    "rendered": "/ocpu/library/doexercises/R/renderRmd"
+}
 
 headers = {
     "Content-Type": "application/json",
@@ -24,20 +28,23 @@ headers = {
 parser = argparse.ArgumentParser(
     description="Scarica soluzioni dalla piattaforma DoExercises")
 parser.add_argument("-u", "--username",
-                    help="username (nome.cognome)", default="", type=str, nargs=1)
+                    help="username (nome.cognome)", default="", type=str)
 parser.add_argument("-m", "--matricola",
-                    help="numero di matricola", default="", type=str, nargs=1)
+                    help="numero di matricola", default="", type=str)
 parser.add_argument("-f", "--force",
-                    help="salta il controllo dei file già scaricati e li ri-scarica tutti", action="store_true")
-parser.add_argument("-o", "--output", help="definisce cartella di output dei file HTML",
-                    default="./html/", type=str, nargs=1)
+                    help="salta il controllo dei file già scaricati e li riscarica tutti", action="store_true")
+parser.add_argument("-o", "--htmlout", help="definisce cartella di output dei file HTML",
+                    default="./html/", type=str)
+parser.add_argument("-p", "--pdfout", help="definisce cartella di output dei file PDF",
+                    default="./pdf/", type=str)
+parser.add_argument("--wk", help="definisce il percorso dell'eseguibile di wkhtmltopdf",
+                    default="wkhtmltopdf", type=str)
+parser.add_argument("--nopdf", help="disabilita la conversione in pdf", default=False, action="store_true")
 parser.add_argument("-v", "--verbose",
                     help="aumenta verbosità dei log (stampa risposte del server etc)", action="store_true")
 parser.add_argument("-j", "--jobs",
-                    help="controlla il numero di thread usati per scaricare i file", default=4, nargs=1)
+                    help="controlla il numero di thread usati per scaricare i file e convertire in PDF", default=4)
 cli_args = parser.parse_args()
-
-pool = ThreadPool(cli_args.jobs)
 
 
 class Log():
@@ -55,6 +62,7 @@ class Log():
     @staticmethod
     def info(text: str, args: str = "") -> None:
         """Print and format an info message
+
         Parameters
         ----------
         text : str
@@ -68,6 +76,7 @@ class Log():
     @staticmethod
     def error(text: str, args: str = "") -> None:
         """Print and format an error message (red)
+
         Parameters
         ----------
         text : str
@@ -81,6 +90,7 @@ class Log():
     @staticmethod
     def success(text: str, args: str = "") -> None:
         """Print and format a success message (green)
+
         Parameters
         ----------
         text : str
@@ -94,6 +104,7 @@ class Log():
     @staticmethod
     def debug(text: str, args: str = "") -> None:
         """Print and format a debug message (indented)
+
         Parameters
         ----------
         text : str
@@ -108,6 +119,7 @@ class Log():
 
 def login() -> str:
     """Creates a new session on DoExercises
+
     Returns
     -------
     str
@@ -119,7 +131,7 @@ def login() -> str:
     }
 
     try:
-        resp = requests.post(root_url + solutions_address,
+        resp = requests.post(URLS["root"] + URLS["solutions"],
                              headers=headers, json=body)
     except requests.exceptions.RequestException as e:
         raise SystemExit(e)
@@ -129,7 +141,9 @@ def login() -> str:
 
 
 def fetch_file_names(path: str) -> List[str]:
-    """Fetches all the .Rmd filenames from DoExercises' storage
+    """
+    Fetches all the .Rmd filenames from DoExercises' storage
+    
     Parameters
     ----------
     path : str
@@ -141,7 +155,7 @@ def fetch_file_names(path: str) -> List[str]:
         The list of filenames found from the request
     """
     try:
-        resp = requests.get(root_url + path, headers=headers)
+        resp = requests.get(URLS["root"] + path, headers=headers)
     except requests.exceptions.RequestException as e:
         raise SystemExit(e)
     filenames = resp.content.decode("UTF-8").split("$files")[1]
@@ -160,7 +174,6 @@ def fetch_rendered_files(filenames: List[str], outfolder: str) -> None:
     outfolder : str
         The folder in which to place the downloaded files
     """
-
     def _fetch_file(filename: str) -> None:
         outfile = filename.replace(".Rmd", ".html")
         body = {
@@ -169,23 +182,35 @@ def fetch_rendered_files(filenames: List[str], outfolder: str) -> None:
         }
         Log.info("Downloading {}", outfile)
         try:
-            resp = requests.post(root_url + renderRmd_address,
+            resp = requests.post(URLS["root"] + URLS["rendered"],
                                  headers=headers, json=body)
         except requests.exceptions.RequestException as e:
             raise SystemExit(e)
         res_path = re.findall(r".*html$", resp.content.decode("UTF-8"), re.MULTILINE)[0]
         Log.debug("Found path: {}", res_path)
-        urllib.request.urlretrieve(root_url + res_path, outfolder + outfile)
+        urllib.request.urlretrieve(URLS["root"] + res_path, outfolder + outfile)
 
+    pool = ThreadPool(cli_args.jobs)
     Log.debug("Using {} threads", cli_args.jobs)
-    pool.map(_fetch_file, filenames)
+    try:
+        pool.map(_fetch_file, filenames)
+    except KeyboardInterrupt:
+        Log.error("Terminating prematurely")
+        Log.info("Finishing pending downloads")
+        # Wait for all downloads to finish
+        pool.terminate()
+        pool.join()
+        sys.exit(1)
+        return
     pool.close()
+    pool.join()
+    Log.success("Finished downloading")
 
 
-def check_existing_files(filenames: List[str], outfolder: str) -> List[str]:
-    """
-    Checks whether any files from a list of .Rmd files was already downloaded
+def check_existing_files(filenames: List[str], outfolder: str, ext: str = "") -> List[str]:
+    """Checks whether any files from a list of .Rmd files was already downloaded
     in the ouput folder
+
     Parameters
     ----------
     filenames : List[str]
@@ -193,16 +218,157 @@ def check_existing_files(filenames: List[str], outfolder: str) -> List[str]:
 
     outfolder : str
         The folder in which downloaded files are placed
+
+    ext : str, optional
+        If set, replaces each file extension with this parameter
+
+    Returns
+    -------
+    List[str]
+        The elements of `filenames` which are not present in `outfolder`
     """
+    def _format_filename(filename: str) -> str:
+        if ext == "": return filename
+        return os.path.splitext(filename)[0] + ext
+
     Log.info("Checking existing files")
     ret = []
     for fn in filenames:
-        fn_noext = fn.replace(".Rmd", ".html")
-        if os.path.isfile(outfolder + fn_noext): continue
+        # If a file with extension `ext` already exists in `outfolder`, skip it
+        if os.path.isfile(outfolder + _format_filename(fn)): continue
         ret.append(fn)
 
     Log.debug("Skipping {} files", len(filenames) - len(ret))
     return ret
+
+
+def which(cmd, mode=os.F_OK | os.X_OK, path=None):
+    """Given a command, mode, and a PATH string, return the path which
+    conforms to the given mode on the PATH, or None if there is no such
+    file.
+    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
+    of os.environ.get("PATH"), or can be overridden with a custom search
+    path.
+    """
+    def _access_check(fn, mode):
+        return (os.path.exists(fn) and os.access(fn, mode)
+            and not os.path.isdir(fn))
+
+    # If we're given a path with a directory part, look it up directly rather
+    # than referring to PATH directories. This includes checking relative to the
+    # current directory, e.g. ./script
+    if os.path.dirname(cmd):
+        if _access_check(cmd, mode):
+            return cmd
+        return None
+
+    use_bytes = isinstance(cmd, bytes)
+
+    if path is None:
+        path = os.environ.get("PATH", None)
+        if path is None:
+            try:
+                path = os.confstr("CS_PATH")
+            except (AttributeError, ValueError):
+                # os.confstr() or CS_PATH is not available
+                path = os.defpath
+        # bpo-35755: Don't use os.defpath if the PATH environment variable is
+        # set to an empty string
+
+    # PATH='' doesn't match, whereas PATH=':' looks in the current directory
+    if not path:
+        return None
+
+    path = os.fsdecode(path)
+    path = path.split(os.pathsep)
+
+    if sys.platform == "win32":
+        # The current directory takes precedence on Windows.
+        if os.curdir not in path:
+            path.insert(0, os.curdir)
+
+        # PATHEXT is necessary to check on Windows.
+        pathext = os.environ.get("PATHEXT", "").split(os.path.sep)
+        # See if the given file matches any of the expected path extensions.
+        # This will allow us to short circuit when given "python.exe".
+        # If it does match, only test that one, otherwise we have to try
+        # others.
+        if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
+            files = [cmd]
+        else:
+            files = [cmd + ext for ext in pathext]
+    else:
+        # On other platforms you don't have things like PATHEXT to tell you
+        # what file suffixes are executable, so just pass on cmd as-is.
+        files = [cmd]
+
+    seen = set()
+    for dir in path:
+        normdir = os.path.normcase(dir)
+        if not normdir in seen:
+            seen.add(normdir)
+            for thefile in files:
+                name = os.path.join(dir, thefile)
+                if _access_check(name, mode):
+                    return name
+    return None
+
+
+def convert_to_pdf(htmlfolder: str, filenames: List[str], outfolder: str = "./pdf/", cmd: str = "wkhtmltopdf") -> None:
+    """Converts a list of files in a folder to PDF using `wkhtmltopdf`. If `xvfb-run` is present,
+    the process is automatically parallelized
+
+    Parameters
+    ----------
+    htmlfolder : str
+        The folder containing the web pages to convert
+    
+    filenames : str
+        The list of filenames to convert
+
+    outfolder : str, optional
+        The folder where PDF files are to be placed
+
+    cmd : str, optional
+        The path of the `wkhtmltopdf` executable
+    """
+    def _convert_file_parallel(filename: str):
+        infile = filename.replace(".Rmd", ".html")
+        outfile = filename.replace(".Rmd", ".pdf")
+        os.system(
+            "xvfb-run --auto-servernum --server-args='-screen 0, 1920x1080x24' {} --use-xserver --javascript-delay 4000 ./{} ./pdf/{}"
+                .format(cmd, htmlfolder + infile, outfile)
+        )
+
+    def _convert_file(filename: str):
+        infile = filename.replace(".Rmd", ".html")
+        outfile = filename.replace(".Rmd", ".pdf")
+        os.system("{} --javascript-delay 4000 ./{} ./pdf/{}".format(cmd, htmlfolder + infile, outfile))
+
+    pool = ThreadPool(cli_args.jobs)
+    Log.info("Converting {} files to PDF", len(filenames))
+
+    # Use xvfb-run if installed only on Linux, to convert files concurrently
+    if which("xvfb-run") and sys.platform.startswith("linux"):
+        Log.info("Detected xfvb-run. Using {} threads", cli_args.jobs)
+        try:
+            pool.map(_convert_file_parallel, filenames)
+        except KeyboardInterrupt:
+            Log.error("Terminating prematurely")
+            Log.info("Finishing pending conversions")
+            # Wait for all conversions to finish
+            pool.terminate()
+            pool.join()
+            sys.exit(1)
+            return
+        pool.close()
+        pool.join()
+    else:
+        for fn in filenames:
+            _convert_file(fn)
+
+    Log.success("Finished converting files to PDF")
+
 
 if __name__ == "__main__":
     # Check username and matricola
@@ -215,26 +381,42 @@ if __name__ == "__main__":
 
     path = login()
 
-    outfolder = cli_args.output
+    html_outfolder = cli_args.htmlout
     # Sanitize the output path: append a '/' if not present already
-    if outfolder[-1] != "/":
-        outfolder += "/"
+    if html_outfolder[-1] != os.path.sep:
+        html_outfolder += os.path.sep
     # Create the folder if it doesn't exist yet
-    if not os.path.exists(outfolder):
+    if not os.path.exists(html_outfolder):
         Log.info("Creating output folder")
-        os.makedirs(outfolder)
+        os.makedirs(html_outfolder)
 
-    filenames = check_existing_files(fetch_file_names(path), outfolder)
+    # Get all the .Rmd filenames from the server
+    filenames = fetch_file_names(path)
+    fetch_rendered_files(
+        check_existing_files(filenames, html_outfolder, ".html"), 
+        html_outfolder
+    )
 
-    try:
-        fetch_rendered_files(filenames, outfolder)
-    except KeyboardInterrupt:
-        Log.error("Terminating prematurely")
-        Log.info("Finishing pending downloads")
-        # Wait for all downloads to finish
-        pool.terminate()
-        pool.join()
+    # Check if wkhtmltopdf is installed
+    wkhtmltopdf = which(cli_args.wk)
+    if not cli_args.nopdf and not wkhtmltopdf:
+        Log.error("wkhtmltopdf not installed (or not found as '{}') - skipping PDF conversion", cli_args.wk)
         sys.exit(1)
-
-    pool.join()
-    Log.success("Finished downloading")
+    elif cli_args.nopdf:
+        sys.exit(0)
+    
+    pdf_outfolder = cli_args.pdfout
+    # Sanitize the output path: append a '/' if not present already
+    if pdf_outfolder[-1] != os.path.sep:
+        pdf_outfolder += os.path.sep
+    # Create the folder if it doesn't exist yet
+    if not os.path.exists(pdf_outfolder):
+        Log.info("Creating PDF output folder")
+        os.makedirs(pdf_outfolder)
+    # Run the conversion
+    convert_to_pdf(
+        html_outfolder,
+        check_existing_files(filenames, html_outfolder, ".pdf"),
+        cli_args.pdfout,
+        cli_args.wk
+    )


### PR DESCRIPTION
Messaggio commit
> Aggiunta conversione a PDF tramite wkhtmltopdf: funzione convert_to_pdf(), multithreading su Linux con xfvb-run, aggiunte opzioni da riga di comando per controllo di cartelle varie, per skippare la conversione in PDF (solo download), per controllo dell'eseguibile di wkhtmltopdf. Spostata parallelizzazione dentro le singole funzioni (per usare più di una ThreadPool), aggiunta funzione which() per controllare esistenza di un comando (sia Unix che Windows)

Questa PR è bella grossa, comunque ho testato praticamente tutto e funziona bene su Linux. `wkhtmltopdf` è un po' limitato per quanto riguarda multithreading perchè è legato a ogni singola istanza di X11 (solo su Linux) quindi l'unico modo possibile di parallelizzarlo è tramite `xfvb-run` che simula multipli dekstop virtuali; su WIndows non c'è modo di usare più processi per la conversione